### PR TITLE
Fix edit view survey bug

### DIFF
--- a/server/queries/updateSurvey.js
+++ b/server/queries/updateSurvey.js
@@ -10,8 +10,6 @@ const updateSurvey = async (surveyId, changes) => {
     const surveys = db.collection('Surveys');
     const questions = db.collection('Questions');
 
-    console.log('CHANGES', changes);
-
     // checking if survey is anon
     const surveyBeforeChanges = await surveys.findOne({
       _id: ObjectID(surveyId),
@@ -69,8 +67,6 @@ const updateSurvey = async (surveyId, changes) => {
           : changes.recipients,
         questions: orderedQuestionIds,
       };
-      console.log('CHANGES TO BE MADE', changesToBeMade);
-
       await surveys.updateOne(
         {
           _id: ObjectID(surveyId),
@@ -82,7 +78,6 @@ const updateSurvey = async (surveyId, changes) => {
       const result = await surveys.findOne({
         _id: ObjectID(surveyId),
       });
-      console.log('UPDATED SURVEY IN COLL', result);
       return result;
     }
     // if recipient has answered
@@ -116,7 +111,6 @@ const updateSurvey = async (surveyId, changes) => {
         $set: changes,
       },
     );
-    console.log('IT ACTUALLY STOPPED HERE', result);
 
     return result;
   } catch (err) {

--- a/server/queries/updateSurvey.js
+++ b/server/queries/updateSurvey.js
@@ -10,6 +10,8 @@ const updateSurvey = async (surveyId, changes) => {
     const surveys = db.collection('Surveys');
     const questions = db.collection('Questions');
 
+    console.log('CHANGES', changes);
+
     // checking if survey is anon
     const surveyBeforeChanges = await surveys.findOne({
       _id: ObjectID(surveyId),
@@ -67,6 +69,8 @@ const updateSurvey = async (surveyId, changes) => {
           : changes.recipients,
         questions: orderedQuestionIds,
       };
+      console.log('CHANGES TO BE MADE', changesToBeMade);
+
       await surveys.updateOne(
         {
           _id: ObjectID(surveyId),
@@ -75,9 +79,11 @@ const updateSurvey = async (surveyId, changes) => {
           $set: changesToBeMade,
         },
       );
-      await surveys.findOne({
+      const result = await surveys.findOne({
         _id: ObjectID(surveyId),
       });
+      console.log('UPDATED SURVEY IN COLL', result);
+      return result;
     }
     // if recipient has answered
     if (changes.answers) {
@@ -97,9 +103,9 @@ const updateSurvey = async (surveyId, changes) => {
               answers: changes.answers,
             },
           },
-        })
-      return
-    
+        },
+      );
+      return;
     }
 
     const result = await surveys.updateOne(
@@ -110,6 +116,7 @@ const updateSurvey = async (surveyId, changes) => {
         $set: changes,
       },
     );
+    console.log('IT ACTUALLY STOPPED HERE', result);
 
     return result;
   } catch (err) {

--- a/server/router.js
+++ b/server/router.js
@@ -22,12 +22,12 @@ router.get('/test', (req, res) =>
 );
 
 // TODO change this endpoint when survey routes are protected
-router.get('/surveys:id', getSurveyAndQuestions);
+// router.get('/surveys:id', getSurveyAndQuestions);
 
 router.post('/login', postLogin);
 
-router.patch('/surveys/:id', patchSurvey);
 router.get('/surveys/:id', getSurvey);
+router.patch('/surveys/:id', patchSurvey);
 router.get('/surveys', getSurveys);
 
 router.post('/surveys', postSurveys);

--- a/server/router.js
+++ b/server/router.js
@@ -4,7 +4,7 @@ const router = express();
 
 const getSurveys = require('./handlers/getSurveys');
 const patchSurvey = require('./handlers/patchSurvey');
-const getSurveyAndQuestions = require('./handlers/getSurveyAndQuestions');
+// const getSurveyAndQuestions = require('./handlers/getSurveyAndQuestions');
 
 const getSurvey = require('./handlers/getSurvey');
 const postSurveys = require('./handlers/postSurveys');


### PR DESCRIPTION
this bug had to do with the way I refactored updateSurvey.js 

if there is a key `questions` in the patch body, the query needs to change the Questions collection as well. Then, the changes need to be set accordingly and returned as soon as they are successful. 

Another scenario - that is unrelated to this PR - would be the patch request that gets triggered when a user is taking a survey. If there is a key `answers` in the patch body, then the query will handle the responses field in the survey object, and push that new answer to the survey in the DB

Also, commented out the route GET '/surveys:id' Because it is not being used in the App. Didn't remove it completely, in case an unexpected bug might be found.