### PR TITLE
Stop rerender when snackbar closes

### DIFF
--- a/client/src/components/Main/Main.jsx
+++ b/client/src/components/Main/Main.jsx
@@ -53,11 +53,11 @@ const Main = ({ history }) => {
           return !checkingIfAuthed && auth ? (
             <Component {...props} />
           ) : (
-            <LoadingPageOrRedirect
-              {...props}
-              checkingIfAuthed={checkingIfAuthed}
-            />
-          );
+              <LoadingPageOrRedirect
+                {...props}
+                checkingIfAuthed={checkingIfAuthed}
+              />
+            );
         }}
       />
     );
@@ -72,7 +72,7 @@ const Main = ({ history }) => {
   const { message, variant, timeOpened } = useSelector(
     (state) => state.snackbarReducer.snackbar,
   );
-  const { open } = useSelector((state) => state.snackbarReducer);
+
 
   return (
     <main>
@@ -89,9 +89,8 @@ const Main = ({ history }) => {
           </Switch>
         </Box>
       </Box>
-      {open && (
-        <Snackbar message={message} variant={variant} timeopened={timeOpened} />
-      )}
+      <Snackbar message={message} variant={variant} timeopened={timeOpened} />
+      )
     </main>
   );
 };

--- a/client/src/components/Snackbar/index.jsx
+++ b/client/src/components/Snackbar/index.jsx
@@ -17,7 +17,7 @@ import {
 } from '@material-ui/icons';
 import { amber, green } from '@material-ui/core/colors';
 
-import { SET_SNACKBAR_OPEN }  from '../../store/actions/snackbarActions';
+import { SET_SNACKBAR_OPEN } from '../../store/actions/snackbarActions';
 
 
 const variantIcon = {
@@ -121,7 +121,7 @@ const CustomizedSnackbars = ({ message, variant, timeopened }) => {
   };
 
   return (
-    message && (
+    message && open && (
       <div>
         <Snackbar
           anchorOrigin={{

--- a/client/src/pages/SurveyDetail/index.jsx
+++ b/client/src/pages/SurveyDetail/index.jsx
@@ -30,7 +30,6 @@ const publishSurvey = async (_id, dispatch) => {
       status: 'active',
       datePublished: Date.now(),
     });
-    console.log(response)
     const payload = response.status === 204;
     dispatch({ type: 'SET_SUCCESSFUL_PUBLISH', payload });
   } catch (err) {

--- a/client/src/pages/SurveyDetail/index.jsx
+++ b/client/src/pages/SurveyDetail/index.jsx
@@ -25,12 +25,18 @@ import ProgressWheel from '../../components/ProgressWheel/ProgressWheel';
 import formatDate from '../../utils/formatDate';
 
 const publishSurvey = async (_id, dispatch) => {
-  const response = await axios.patch(`/surveys/${_id}`, {
-    status: 'active',
-    datePublished: Date.now(),
-  });
-  const payload = response.status === 204;
-  dispatch({ type: 'SET_SUCCESSFUL_PUBLISH', payload });
+  try {
+    const response = await axios.patch(`/surveys/${_id}`, {
+      status: 'active',
+      datePublished: Date.now(),
+    });
+    console.log(response)
+    const payload = response.status === 204;
+    dispatch({ type: 'SET_SUCCESSFUL_PUBLISH', payload });
+  } catch (err) {
+    console.error(err.message)
+    dispatch({ type: 'SET_SUCCESSFUL_PUBLISH', payload: false })
+  }
 };
 const setSurveyData = (data, dispatch) => {
   const payload = data;
@@ -46,12 +52,17 @@ const getSurvey = async (idToSend, dispatch) => {
   }
 };
 const closeSurvey = async (_id, dispatch) => {
-  const response = await axios.patch(`/surveys/${_id}`, {
-    status: 'closed',
-    dateClosed: Date.now(),
-  });
-  const payload = response.status === 204;
-  dispatch({ type: 'SET_SUCCESSFUL_CLOSE', payload });
+  try {
+    const response = await axios.patch(`/surveys/${_id}`, {
+      status: 'closed',
+      dateClosed: Date.now(),
+    });
+    const payload = response.status === 204;
+    dispatch({ type: 'SET_SUCCESSFUL_CLOSE', payload });
+  } catch (err) {
+    console.error(err.message)
+    dispatch({ type: 'SET_SUCCESSFUL_CLOSE', payload: false });
+  }
 };
 const PublishSurveyButton = ({ surveyId }) => {
   const dispatch = useDispatch();
@@ -328,16 +339,16 @@ const SurveyDetail = ({ match }) => {
           {recipients.length ? (
             <EmployeeCompletionTable />
           ) : (
-            <Typography>
-              No recipients have been added. Select Edit Survey to start adding.
+              <Typography>
+                No recipients have been added. Select Edit Survey to start adding.
             </Typography>
-          )}
+            )}
 
           {employeeDataForSlack && <SlackModal />}
         </Box>
       )}
-      {successfulPublish && SnackbarPublish()}
-      {successfulClose && SnackbarClose()}
+      {[true, false].includes(successfulPublish) && SnackbarPublish()}
+      {[true, false].includes(successfulClose) && SnackbarClose()}
       <ExportModal />
     </Box>
   );


### PR DESCRIPTION
This fixes an issue that the snackbar was causing main to reload which was a little clunky. It also ensures proper error handling when publishing/closing surveys (including if the connection drops)