### PR TITLE
Split survey endpoints

### DIFF
--- a/client/src/pages/EditSurvey/index.jsx
+++ b/client/src/pages/EditSurvey/index.jsx
@@ -97,7 +97,7 @@ const EditSurvey = ({ match, history }) => {
     };
     const getSurvey = async () => {
       try {
-        const { data } = await axios.get(`/surveys/${id}`);
+        const { data } = await axios.get(`/surveys/${id}?responses=true`);
         setSurveyData(data);
       } catch (error) {
         setSurveyData({});

--- a/client/src/pages/SurveyBuilderFromTemplate/components/TemplateSurveysTable.jsx
+++ b/client/src/pages/SurveyBuilderFromTemplate/components/TemplateSurveysTable.jsx
@@ -32,7 +32,7 @@ const TemplateSurveysTable = ({ history }) => {
   const goToSurveyBuilderWithPreexistingData = async (id) => {
     let surveySelected;
     try {
-      const { data } = await axios.get(`/surveys/${id}`);
+      const { data } = await axios.get(`/surveys/${id}?responses=true`);
       surveySelected = (({ _id, ...others }) => ({ ...others }))(data);
 
       surveySelected.questions = surveySelected.questions.map((question) => {

--- a/client/src/pages/SurveyDetail/index.jsx
+++ b/client/src/pages/SurveyDetail/index.jsx
@@ -33,8 +33,8 @@ const publishSurvey = async (_id, dispatch) => {
     const payload = response.status === 204;
     dispatch({ type: 'SET_SUCCESSFUL_PUBLISH', payload });
   } catch (err) {
-    console.error(err.message)
-    dispatch({ type: 'SET_SUCCESSFUL_PUBLISH', payload: false })
+    console.error(err.message);
+    dispatch({ type: 'SET_SUCCESSFUL_PUBLISH', payload: false });
   }
 };
 const setSurveyData = (data, dispatch) => {
@@ -44,7 +44,7 @@ const setSurveyData = (data, dispatch) => {
 };
 const getSurvey = async (idToSend, dispatch) => {
   try {
-    const { data } = await axios.get(`/surveys/${idToSend}`);
+    const { data } = await axios.get(`/surveys/${idToSend}?responses=true`);
     setSurveyData(data, dispatch);
   } catch (error) {
     setSurveyData({}, dispatch);
@@ -59,7 +59,7 @@ const closeSurvey = async (_id, dispatch) => {
     const payload = response.status === 204;
     dispatch({ type: 'SET_SUCCESSFUL_CLOSE', payload });
   } catch (err) {
-    console.error(err.message)
+    console.error(err.message);
     dispatch({ type: 'SET_SUCCESSFUL_CLOSE', payload: false });
   }
 };
@@ -338,10 +338,10 @@ const SurveyDetail = ({ match }) => {
           {recipients.length ? (
             <EmployeeCompletionTable />
           ) : (
-              <Typography>
-                No recipients have been added. Select Edit Survey to start adding.
+            <Typography>
+              No recipients have been added. Select Edit Survey to start adding.
             </Typography>
-            )}
+          )}
 
           {employeeDataForSlack && <SlackModal />}
         </Box>

--- a/client/src/pages/TakeSurvey/index.jsx
+++ b/client/src/pages/TakeSurvey/index.jsx
@@ -7,7 +7,7 @@ import QuestionCard from './QuestionCard/QuestionCard';
 import SurveyDescription from './SurveyDescription/SurveyDescription';
 import SurveySubmit from './SurveySubmit/SurveySubmit';
 import SurveyClosedMessage from './SurveyClosedMessage/SurveyClosedMessage';
-import AlreadyCompletedMessage from './AlreadyCompletedMessage/AlreadyCompletedMessage'
+import AlreadyCompletedMessage from './AlreadyCompletedMessage/AlreadyCompletedMessage';
 
 const TakeSurvey = ({ match }) => {
   const dispatch = useDispatch();
@@ -15,38 +15,49 @@ const TakeSurvey = ({ match }) => {
     (state) => state.takeSurveyReducer.activeQuestion,
   );
 
-  const { employeeId, surveyId } = match.params
+  const { employeeId, surveyId } = match.params;
 
   useEffect(() => {
     const getSurvey = async () => {
       const response = await axios.get(`/surveys/${surveyId}`);
-      console.log("response: ", response)
       dispatch({ type: 'SET_SURVEY', payload: response.data });
       dispatch({ type: 'SET_QUESTIONS', payload: response.data.questions });
       dispatch({ type: 'SET_INITIAL_ANSWERS' });
-      dispatch({ type: 'SET_SURVEY_CLOSED', payload: response.data.status === 'closed' })
-      dispatch({ type: 'SET_EMPLOYEE_COMPLETED', payload: response.data.recipients.filter(recipient => recipient.employeeId === employeeId)[0].completed === true })
+      dispatch({
+        type: 'SET_SURVEY_CLOSED',
+        payload: response.data.status === 'closed',
+      });
+      dispatch({
+        type: 'SET_EMPLOYEE_COMPLETED',
+        payload:
+          response.data.recipients.filter(
+            (recipient) => recipient.employeeId === employeeId,
+          )[0].completed === true,
+      });
     };
     getSurvey();
-
   }, [dispatch, employeeId, surveyId]);
 
-  const surveyClosed = useSelector(state => state.takeSurveyReducer.surveyClosed)
+  const surveyClosed = useSelector(
+    (state) => state.takeSurveyReducer.surveyClosed,
+  );
 
-  const employeeHasCompleted = useSelector(state => state.takeSurveyReducer.employeeHasCompleted)
+  const employeeHasCompleted = useSelector(
+    (state) => state.takeSurveyReducer.employeeHasCompleted,
+  );
 
   if (employeeHasCompleted) {
-    return <AlreadyCompletedMessage />
-  } else if (surveyClosed) {
-    return <SurveyClosedMessage />
+    return <AlreadyCompletedMessage />;
+  }
+  if (surveyClosed) {
+    return <SurveyClosedMessage />;
   }
   return (
-    <Box display='flex' flexDirection='column' >
+    <Box display='flex' flexDirection='column'>
       <UserProgressStepper />
       {activeQuestion === 'start' ? <SurveyDescription /> : <QuestionCard />}
       {activeQuestion === 'end' && <SurveySubmit match={match} />}
-    </Box >)
-
-
+    </Box>
+  );
 };
 export default TakeSurvey;

--- a/server/handlers/getSurvey.js
+++ b/server/handlers/getSurvey.js
@@ -1,14 +1,54 @@
 /* eslint-ignore no-console */
+const passport = require('passport');
 const readSurvey = require('../queries/readSurvey');
 
-const getSurvey = async (req, res) => {
+const getSurvey = async (req, res, next) => {
   try {
     // checks if params contains key id or if params itself is just one string
     const { id } = req.params;
-    const result = await readSurvey(id.toString());
-    res.status(200).json(result);
+    const { responses } = req.query || { responses: false };
+
+    const responsesRequested = responses === 'true';
+
+    const respondWithSurveyData = async (withResponses) => {
+      try {
+        const result = await readSurvey(id.toString(), withResponses);
+        return res.status(200).json(result);
+      } catch (error) {
+        throw Error({ message: 'Failed to read survey data.' });
+      }
+    };
+
+    if (responsesRequested) {
+      return passport.authenticate(
+        'jwt',
+        { session: false },
+        (err, user, info) => {
+          try {
+            if (err) {
+              throw new Error(err);
+            }
+
+            if (info) {
+              return res.status(401).json({ message: info.message });
+            }
+
+            if (user) {
+              // success case. Can load up protected route.
+              return respondWithSurveyData(responsesRequested);
+            }
+
+            return res.status(403).json({ message: 'No auth token' });
+          } catch (error) {
+            return res.status(500).json({ message: error.message });
+          }
+        },
+      )(req, res, next);
+    }
+
+    return respondWithSurveyData(false);
   } catch (err) {
-    res
+    return res
       .status(500)
       .json(
         "We're experiencing some issues on our end. Please inform the engineers and we will get back to you",

--- a/server/handlers/patchSurvey.js
+++ b/server/handlers/patchSurvey.js
@@ -1,13 +1,65 @@
+const Joi = require('@hapi/joi');
+const passport = require('passport');
 const updateSurvey = require('../queries/updateSurvey');
 
-const patchSurvey = async (req, res) => {
+const schema = Joi.object({
+  anonymous: Joi.bool(),
+
+  answers: Joi.array()
+    .items(
+      Joi.object({
+        questionId: Joi.string().required(),
+        answer: Joi.string()
+          .allow('')
+          .required(),
+        comment: Joi.string().allow(''),
+      }),
+    )
+    .required(),
+
+  employeeId: Joi.string().required(),
+});
+
+/*
+anonymous: true
+answers: [{questionId: "707f1f87bcf86dd799439011", answer: "good", comment: ""},…]
+employeeId: "507f1f77bcf86cd799439013"
+*/
+const patchSurvey = async (req, res, next) => {
   try {
     const { body } = req;
     const { id } = req.params;
-    const result = await updateSurvey(id, body);
-    res.status(204).json(result);
+
+    const addSurveyResponse = schema.validate(body).error === undefined;
+
+    if (addSurveyResponse) {
+      const result = await updateSurvey(id, body);
+      return res.status(204).json(result);
+    }
+
+    return passport.authenticate(
+      'jwt',
+      { session: false },
+      async (err, user, info) => {
+        if (err) {
+          throw new Error(err);
+        }
+
+        if (info) {
+          return res.status(401).json({ message: info.message });
+        }
+
+        if (user) {
+          // success case. Can load up protected route.
+          const result = await updateSurvey(id, body);
+          return res.status(204).json(result);
+        }
+
+        return res.status(403).json({ message: 'No auth token' });
+      },
+    )(req, res, next);
   } catch (err) {
-    res
+    return res
       .status(500)
       .json(
         "We're experiencing some issues on our end. Please inform the engineers and we will get back to you",

--- a/server/handlers/patchSurvey.test.js
+++ b/server/handlers/patchSurvey.test.js
@@ -4,10 +4,26 @@ const { initDb, closeDb } = require('../databaseConnection');
 const app = require('../app');
 
 describe('Testing PATCH /surveys/:id', () => {
-  beforeEach(() => initDb());
+  beforeEach(async () => initDb());
   afterEach(() => closeDb());
+
   it('Responds with status 204 when the survey has been updated successfully.', async (done) => {
     try {
+      const loginResponse = await request(app)
+        .post('/login')
+        .send({
+          username: 'admin',
+          password: 'admin',
+        });
+
+      expect(loginResponse.status).toEqual(200);
+      expect(loginResponse.body.auth).toEqual(true);
+      expect(loginResponse.body.token).toBeDefined();
+
+      const {
+        body: { token },
+      } = loginResponse;
+
       const documentIdToUpdate = '508f1f99bcf86cd799439014';
       const updateWith = {
         status: 'active',
@@ -16,7 +32,8 @@ describe('Testing PATCH /surveys/:id', () => {
       const res = await request(app)
         .patch(`/surveys/${documentIdToUpdate}`)
         .send(updateWith)
-        .set('Accept', 'application/json');
+        .set('Accept', 'application/json')
+        .set('Authorization', `JWT ${token}`);
 
       expect(res.status).toBe(204);
 

--- a/server/handlers/protected/downloadCSV.js
+++ b/server/handlers/protected/downloadCSV.js
@@ -15,7 +15,7 @@ const downloadCSV = async (req, res, next) => {
     if (user) {
       try {
         const id = !req.params.id ? req.params : req.params.id;
-        const survey = await readSurvey(id.toString());
+        const survey = await readSurvey(id.toString(), true);
         const { responses, questions } = survey;
         const anonymous = survey.anonymous || req.params.anonymous === 'true';
         let employees;

--- a/server/queries/readSurvey.js
+++ b/server/queries/readSurvey.js
@@ -2,7 +2,7 @@
 const { ObjectID } = require('mongodb');
 const { getDb } = require('../databaseConnection');
 
-const readSurvey = async (_id) => {
+const readSurvey = async (_id, withResponses = false) => {
   try {
     const db = getDb();
     const surveys = db.collection('Surveys');
@@ -10,6 +10,8 @@ const readSurvey = async (_id) => {
     const survey = await surveys.findOne({
       _id: ObjectID(_id),
     });
+
+    if (!withResponses) delete survey.responses;
 
     const surveyQuestions = survey.questions;
 

--- a/server/queries/readSurvey.test.js
+++ b/server/queries/readSurvey.test.js
@@ -88,7 +88,7 @@ describe('Testing readSurvey retrieves the correct document.', () => {
         responses: [],
       };
       expect.assertions(1);
-      const readDocument = await readSurvey('508f1f99bcf86cd799439014');
+      const readDocument = await readSurvey('508f1f99bcf86cd799439014', true);
       expect(readDocument).toStrictEqual(documentToFind);
 
       return done();


### PR DESCRIPTION
The `GET /surveys/:id` endpoint requires a query parameter `?responses=true` to return responses from that endpoint. This requires a valid JWT token to retrieve this.

The `PATCH /surveys/:id` endpoint will only add responses of the JOI validation schema at bottom of this description. Any other data that fails this schema will require authentication of JWT token.

```
const schema = Joi.object({
  anonymous: Joi.bool(),

  answers: Joi.array()
    .items(
      Joi.object({
        questionId: Joi.string().required(),
        answer: Joi.string()
          .allow('')
          .required(),
        comment: Joi.string().allow(''),
      }),
    )
    .required(),

  employeeId: Joi.string().required(),
});
```