### PR TITLE
Db control

### DIFF
--- a/server/dummyData/dummyAdmins.js
+++ b/server/dummyData/dummyAdmins.js
@@ -3,7 +3,7 @@ const { ObjectID } = require('mongodb');
 module.exports = [
   {
     _id: ObjectID('519f1f77bcf86cd799439173'),
-    username: 'admin',
+    username: 'steven.bianchi@beamery.com',
     password: 'admin',
     type: 'admin',
     employeeId: '123123',

--- a/server/dummyData/dummyQuestions.js
+++ b/server/dummyData/dummyQuestions.js
@@ -19,7 +19,7 @@ module.exports = [
   },
   {
     _id: ObjectID('707f1f87bcf86dd799439121'),
-    title: "I see myself still working at B*amery in two years' time",
+    title: "I see myself still working at Beamery in two years' time",
     type: 'multichoice',
     required: true,
     commentEnabled: true,
@@ -33,7 +33,7 @@ module.exports = [
   },
   {
     _id: ObjectID('707f1f87bcf76dd789439121'),
-    title: 'I am proud to work for B*amery',
+    title: 'I am proud to work for Beamery',
     type: 'multichoice',
     required: true,
     commentEnabled: false,


### PR DESCRIPTION
This adds a file to `server` that when run will reset the database with the dummy data. The `NODE_ENV`, `MONGO_URI` and `SLACK_OAUTH` will need to be configured in the terminal using `export <env-variable>=<blah blah>`. 